### PR TITLE
Zac filter chained with differential filter

### DIFF
--- a/src/zac.jl
+++ b/src/zac.jl
@@ -1,4 +1,4 @@
-export zac_filter_coefficients
+export zac_filter_coefficients, create_zac_filter
 
 """
     zac_filter_coefficients(s, τₛ, A, L, FT)
@@ -13,4 +13,40 @@ ZAC filter function as defined in Eq. (7) in [Eur. Phys. J. C (2015) 75:255]
     elseif L + FT <= t <= 2L + FT
         sinh((2L + FT - t)/τₛ) + A*((L + FT - t)*(2L + FT - t))
     end
+end
+
+"""
+
+    ZACfilter similar to cpp script
+"""
+@inline tons(u, dt) = ceil(u / dt) |> Int
+
+create_zac_filter(Nₜ, FTₜ, τₜ, Δt) = begin
+    # convert parameters to integers respecting nano seconds resolution
+    N, τₛ, FT = tons.((Nₜ, τₜ, FTₜ), Δt)
+
+    # define length of filter
+    L = ((N - FT) % 2 == 0) ? L = (N - FT)÷2 : (FT += 1; true) && (N - FT)÷2
+    CUSP = Array{Float64, 1}(undef, N)
+    Poly = zeros(Int, N)
+
+    # normalization constant, such that the ZAC filter is equal to one at the 
+    # center
+    C = 1/sinh(L/τₛ)
+
+    # build the cusp filter (sinh part) and polynomial part
+    for i in 1:L
+        y = sinh(i/τₛ)*C
+        CUSP[i] = CUSP[N-i+1] = y
+        Poly[i] = Poly[N - i + 1] = i*(i - L)
+    end
+    for i in L+1:L+FT
+        CUSP[i] = 1.
+    end
+
+    ∫Poly = sum(Poly)
+    ∫CUSP = sum(CUSP)
+
+    # build the ZAC filter
+    return CUSP .+ (Poly .* (-∫CUSP/∫Poly))
 end

--- a/src/zac.jl
+++ b/src/zac.jl
@@ -1,17 +1,39 @@
-export zac_filter_coefficients, create_zac_filter
+export zac_filter_coefficients, create_zac_filter, 
+       zac_diff_filter_coefficients, create_zac_diff_filter
+
+@inline _A(L, FT, τₛ) = 6/L^3 * (τₛ*(cosh(L/τₛ) - 1) + sinh(L/τₛ)*FT/2)
 
 """
-    zac_filter_coefficients(s, τₛ, A, L, FT)
-
+    zac_filter_coefficients(s, τₛ, L, FT)
+       
 ZAC filter function as defined in Eq. (7) in [Eur. Phys. J. C (2015) 75:255]
 """
-@inline zac_filter_coefficients(t, τₛ, A, L, FT) = begin
+@inline zac_filter_coefficients(t, τₛ, L, FT) = begin
     if 0 <= t < L
-        sinh(t / τₛ) + A*t*(t - L)
-    elseif L <= t < L + FT
+        sinh(t / τₛ) + _A(L, FT, τₛ)*t*(t - L)
+    elseif L <= t <= L + FT
         sinh(L / τₛ)
     elseif L + FT <= t <= 2L + FT
-        sinh((2L + FT - t)/τₛ) + A*((L + FT - t)*(2L + FT - t))
+        sinh((2L + FT - t)/τₛ) + _A(L, FT, τₛ)*(L + FT - t)*(2L + FT - t)
+    else
+        0
+    end
+end
+
+@inline zac_diff_filter_coefficients(t, Δt, τ, τₛ, L, FT) = begin
+    a = exp(-1/τ)
+    if 0 <= t < L
+        A = _A(L, FT, τₛ)
+        # @debug "A = $A"
+        sinh((t+Δt)/τₛ) - a*sinh(t/τₛ) + A*((t + Δt)*Δt + (t + Δt - a*t)*(t - L))
+    elseif L <= t <= L+FT
+        (1-a)*sinh(L/τₛ)
+    elseif L + FT < t <= 2L + FT
+        A = _A(L, FT, τₛ)
+        # @debug "A = $A"
+        -a*(sinh((t+Δt)/τₛ) - sinh(t/τₛ)/a + A*((t + Δt)*Δt + (t + Δt - t/a)*(t - L)))
+    else
+        0
     end
 end
 
@@ -31,7 +53,10 @@ function create_zac_filter(Nₜ, FTₜ, τₜ, Δt)
 
     # define length of filter
     L = ((N - FT) % 2 == 0) ? (N - FT)÷2 : (N - (FT+=1))÷2
-    @debug "Number of bins: $L"
+    @debug "partial length: $L"
+    @debug "Total length of Filter: $N"
+    @debug "exponential decay: $(τₛ)"
+    @debug "Flat top: $FT"
     CUSP = Array{Float64, 1}(undef, N)
     Poly = zeros(Int, N)
 
@@ -50,6 +75,41 @@ function create_zac_filter(Nₜ, FTₜ, τₜ, Δt)
     ∫CUSP = sum(CUSP)
     @debug "∫Poly = $(∫Poly)"
     @debug "∫CUSP = $(∫CUSP)"
+    @debug "A = $(-∫CUSP/∫Poly)"
+    # build the normalized ZAC filter
+    CUSP .+ (Poly .* (-∫CUSP/∫Poly))
+end
+
+function create_zac_diff_filter(Nₜ, FTₜ, τₜ, τ₂ₜ, Δt)
+    # convert parameters to integers respecting whatever resolution is 
+    # given by Δt
+    N, τₛ, FT, τ = tons.((Nₜ, τₜ, FTₜ, τ₂ₜ), Δt)
+
+    # define length of filter
+    L = ((N - FT) % 2 == 0) ? (N - FT)÷2 : (N - (FT+=1))÷2
+    @debug "partial length: $L"
+    @debug "Total length of Filter: $N"
+    @debug "exponential decay: $(τₛ)"
+    @debug "Flat top: $FT"
+    CUSP = Array{Float64, 1}(undef, N)
+    Poly = zeros(Int, N)
+
+    # build the cusp filter (sinh part) and polynomial part
+    for i in 1:L
+        CUSP[i] = CUSP[N-i+1] = sinh(i/τₛ)
+        Poly[i] = Poly[N-i+1] = i*(i - L)
+    end
+    # build the flat top part
+    C = sinh(L/τₛ)
+    for i in 1:FT
+        CUSP[L+i] = C
+    end
+
+    ∫Poly = sum(Poly)
+    ∫CUSP = sum(CUSP)
+    @debug "∫Poly = $(∫Poly)"
+    @debug "∫CUSP = $(∫CUSP)"
+    @debug "A = $(-∫CUSP/∫Poly)"
     # build the normalized ZAC filter
     CUSP .+ (Poly .* (-∫CUSP/∫Poly))
 end

--- a/src/zac.jl
+++ b/src/zac.jl
@@ -21,17 +21,19 @@ ZAC filter function as defined in Eq. (7) in [Eur. Phys. J. C (2015) 75:255]
 end
 
 @inline zac_diff_filter_coefficients(t, Δt, τ, τₛ, L, FT) = begin
-    a = exp(-1/τ)
+    a = exp(-Δt/τ)
     if 0 <= t < L
         A = _A(L, FT, τₛ)
         # @debug "A = $A"
-        sinh((t+Δt)/τₛ) - a*sinh(t/τₛ) + A*((t + Δt)*Δt + (t + Δt - a*t)*(t - L))
+        sinh((t+Δt)/τₛ) - a*sinh(t/τₛ) 
+        + A*((t + Δt)*Δt + (t + Δt - a*t)*(t - L))
     elseif L <= t <= L+FT
         (1-a)*sinh(L/τₛ)
-    elseif L + FT < t <= 2L + FT
+    elseif L + FT < t <= zd2L + FT
         A = _A(L, FT, τₛ)
         # @debug "A = $A"
-        -a*(sinh((t+Δt)/τₛ) - sinh(t/τₛ)/a + A*((t + Δt)*Δt + (t + Δt - t/a)*(t - L)))
+        t̃ = 2L + FT - t
+        -a*(sinh((t̃+Δt)/τₛ) - sinh(t̃/τₛ)/a + A*((t̃ + Δt)*Δt + (t̃ + Δt - t̃/a)*(t̃ - L)))
     else
         0
     end
@@ -71,45 +73,13 @@ function create_zac_filter(Nₜ, FTₜ, τₜ, Δt)
         CUSP[L+i] = C
     end
 
-    ∫Poly = sum(Poly)
-    ∫CUSP = sum(CUSP)
+    ∫Poly = mean(Poly)
+    ∫CUSP = mean(CUSP)
     @debug "∫Poly = $(∫Poly)"
     @debug "∫CUSP = $(∫CUSP)"
     @debug "A = $(-∫CUSP/∫Poly)"
-    # build the normalized ZAC filter
-    CUSP .+ (Poly .* (-∫CUSP/∫Poly))
-end
+    @debug "check normalization: $(sum(CUSP .+ (Poly .* (-∫CUSP/∫Poly))))"
 
-function create_zac_diff_filter(Nₜ, FTₜ, τₜ, τ₂ₜ, Δt)
-    # convert parameters to integers respecting whatever resolution is 
-    # given by Δt
-    N, τₛ, FT, τ = tons.((Nₜ, τₜ, FTₜ, τ₂ₜ), Δt)
-
-    # define length of filter
-    L = ((N - FT) % 2 == 0) ? (N - FT)÷2 : (N - (FT+=1))÷2
-    @debug "partial length: $L"
-    @debug "Total length of Filter: $N"
-    @debug "exponential decay: $(τₛ)"
-    @debug "Flat top: $FT"
-    CUSP = Array{Float64, 1}(undef, N)
-    Poly = zeros(Int, N)
-
-    # build the cusp filter (sinh part) and polynomial part
-    for i in 1:L
-        CUSP[i] = CUSP[N-i+1] = sinh(i/τₛ)
-        Poly[i] = Poly[N-i+1] = i*(i - L)
-    end
-    # build the flat top part
-    C = sinh(L/τₛ)
-    for i in 1:FT
-        CUSP[L+i] = C
-    end
-
-    ∫Poly = sum(Poly)
-    ∫CUSP = sum(CUSP)
-    @debug "∫Poly = $(∫Poly)"
-    @debug "∫CUSP = $(∫CUSP)"
-    @debug "A = $(-∫CUSP/∫Poly)"
     # build the normalized ZAC filter
     CUSP .+ (Poly .* (-∫CUSP/∫Poly))
 end

--- a/src/zac.jl
+++ b/src/zac.jl
@@ -1,5 +1,5 @@
 export zac_filter_coefficients, create_zac_filter, 
-       zac_diff_filter_coefficients, create_zac_diff_filter
+       zac_diff_filter_coefficients
 
 @inline _A(L, FT, τₛ) = 6/L^3 * (τₛ*(cosh(L/τₛ) - 1) + sinh(L/τₛ)*FT/2)
 
@@ -24,16 +24,15 @@ end
     a = exp(-Δt/τ)
     if 0 <= t < L
         A = _A(L, FT, τₛ)
-        # @debug "A = $A"
         sinh((t+Δt)/τₛ) - a*sinh(t/τₛ) 
         + A*((t + Δt)*Δt + (t + Δt - a*t)*(t - L))
     elseif L <= t <= L+FT
         (1-a)*sinh(L/τₛ)
     elseif L + FT < t <= zd2L + FT
         A = _A(L, FT, τₛ)
-        # @debug "A = $A"
         t̃ = 2L + FT - t
-        -a*(sinh((t̃+Δt)/τₛ) - sinh(t̃/τₛ)/a + A*((t̃ + Δt)*Δt + (t̃ + Δt - t̃/a)*(t̃ - L)))
+        -a*(sinh((t̃+Δt)/τₛ) - sinh(t̃/τₛ)/a 
+        + A*((t̃ + Δt)*Δt + (t̃ + Δt - t̃/a)*(t̃ - L)))
     else
         0
     end
@@ -53,12 +52,7 @@ function create_zac_filter(Nₜ, FTₜ, τₜ, Δt)
     # given by Δt
     N, τₛ, FT = tons.((Nₜ, τₜ, FTₜ), Δt)
 
-    # define length of filter
     L = ((N - FT) % 2 == 0) ? (N - FT)÷2 : (N - (FT+=1))÷2
-    @debug "partial length: $L"
-    @debug "Total length of Filter: $N"
-    @debug "exponential decay: $(τₛ)"
-    @debug "Flat top: $FT"
     CUSP = Array{Float64, 1}(undef, N)
     Poly = zeros(Int, N)
 
@@ -75,10 +69,6 @@ function create_zac_filter(Nₜ, FTₜ, τₜ, Δt)
 
     ∫Poly = mean(Poly)
     ∫CUSP = mean(CUSP)
-    @debug "∫Poly = $(∫Poly)"
-    @debug "∫CUSP = $(∫CUSP)"
-    @debug "A = $(-∫CUSP/∫Poly)"
-    @debug "check normalization: $(sum(CUSP .+ (Poly .* (-∫CUSP/∫Poly))))"
 
     # build the normalized ZAC filter
     CUSP .+ (Poly .* (-∫CUSP/∫Poly))


### PR DESCRIPTION
added zac_diff_filter_coefficients and create_zac_filter.
create_zac_filter returns an Array representing only the ZAC filter for the specified parameters. 
zac_diff_filter_coefficients is an analytical expression (similar to zac_filter_coefficients) for the ZAC filter together with a differential filter.
Also added _A(L, FT, tau_s) which computes the normalisation constant needed, based on the original analytical definition of the ZAC filter.

Issues:
- zac_diff_filter_coefficients only supports Unitful.Quanitites if all parameters have the same unit