### PR TITLE
Asymmetric Trapezoidal Filter

### DIFF
--- a/src/trapezoidal_filter.jl
+++ b/src/trapezoidal_filter.jl
@@ -22,11 +22,21 @@ time `avgtime` and a flat top of length `gaptime`.
 Base.@kwdef struct TrapezoidalChargeFilter{
     T <: RealQuantity
 } <: AbstractRadFIRFilter
-    "averaging time"
+    "pre-rise averaging time"
     avgtime::T
 
     "gap time"
     gaptime::T
+
+    "post-rise averaging time"
+    avgtime2::T
+    # alternative constructor for symmetric trapezodial filters
+    function TrapezoidalChargeFilter(avgtime::T, gaptime::T) where {T <: RealQuantity} 
+        new{T}(avgtime, gaptime, avgtime)
+    end
+    function TrapezoidalChargeFilter(avgtime::T, gaptime::T, avgtime2::T) where {T <: RealQuantity} 
+        new{T}(avgtime, gaptime, avgtime2)
+    end
 end
 
 export TrapezoidalChargeFilter
@@ -34,38 +44,41 @@ export TrapezoidalChargeFilter
 Adapt.adapt_structure(to, flt::TrapezoidalChargeFilter) = flt
 
 function ConvolutionFilter(flt::TrapezoidalChargeFilter)
-    navg = Int(flt.avgtime)
-    ngap = Int(flt.gaptime)
+    navg  = Int(flt.avgtime)
+    navg2 = Int(flt.avgtime2)
+    ngap  = Int(flt.gaptime)
     norm_factor = inv(navg)
     T = typeof(norm_factor)
-    params = zeros(T, 2*navg + ngap)
+    params = zeros(T, navg + ngap + navg2)
     fill!(view(params, firstindex(params):(firstindex(params)+navg-1)), +norm_factor)
     fill!(view(params, firstindex(params)+navg+ngap:lastindex(params)), -norm_factor)
     ConvolutionFilter(FFTConvolution(), params)
 end
 
 
-function fltinstance(flt::TrapezoidalChargeFilter, si::SamplingInfo{T}) where T
+function fltinstance(flt::TrapezoidalChargeFilter, si::SamplingInfo{T}) where {T <: RealQuantity} 
     delta_t = step(si.axis)
 
-    navg = round(Int, uconvert(NoUnits, flt.avgtime / delta_t))
-    ngap = round(Int, uconvert(NoUnits, flt.gaptime / delta_t))
+    navg  = round(Int, uconvert(NoUnits, flt.avgtime  / delta_t))
+    ngap  = round(Int, uconvert(NoUnits, flt.gaptime  / delta_t))
+    navg2 = round(Int, uconvert(NoUnits, flt.avgtime2 / delta_t))
 
-    navg >= 1 && ngap >= 0 || throw(ArgumentError("Require navg >= 1 and ngap >= 0"))
-    (2 * navg + ngap) <= _smpllen(si) || throw(ArgumentError("filter must not be longer than input"))
+    navg >= 1 && ngap >= 0 && navg2 >= 1 || throw(ArgumentError("Require navg/navg2 >= 1 and ngap >= 0"))
+    (navg + ngap + navg2) <= _smpllen(si) || throw(ArgumentError("filter must not be longer than input"))
 
-    TrapezoidalChargeFilterInstance{T}(navg, ngap, _smpllen(si))
+    TrapezoidalChargeFilterInstance{T}(navg, ngap, navg2, _smpllen(si))
 end
 
 
 struct TrapezoidalChargeFilterInstance{T<:RealQuantity} <: AbstractRadSigFilterInstance{LinearFiltering}
     navg::Int
     ngap::Int
+    navg2::Int
     n_input::Int
 end
 
 
-_filterlen(fi::TrapezoidalChargeFilterInstance) = 2* fi.navg + fi.ngap
+_filterlen(fi::TrapezoidalChargeFilterInstance) = fi.navg + fi.ngap + fi.navg2
 
 function flt_output_time_axis(fi::TrapezoidalChargeFilterInstance, time::AbstractVector{<:RealQuantity})
     valid_range = (firstindex(time) + _filterlen(fi) - 1):lastindex(time)
@@ -73,21 +86,23 @@ function flt_output_time_axis(fi::TrapezoidalChargeFilterInstance, time::Abstrac
 end
 
 
-@inline function rdfilt!(y::AbstractVector{T}, fi::TrapezoidalChargeFilterInstance{T}, x::AbstractVector{T}) where {T<:Real}
+@inline function rdfilt!(y::AbstractVector{T}, fi::TrapezoidalChargeFilterInstance{U}, x::AbstractVector{U}) where {T<:Real, U<:Real}
     @fastmath begin
-        navg = fi.navg
-        ngap = fi.ngap
+        navg  = fi.navg
+        navg2 = fi.navg2
+        ngap  = fi.ngap
 
         @assert firstindex(y) == firstindex(x)
         @assert lastindex(y) == lastindex(x) - _filterlen(fi) + 1
 
+        # norm_factor = inv(T(navg))*T(navg2)
         norm_factor = inv(T(navg))
         acc::T = zero(T)
 
         offs1 = 0
         offs2 = offs1 + navg
         offs3 = offs2 + ngap
-        offs4 = offs3 + navg
+        offs4 = offs3 + navg2
 
         @assert lastindex(y) + offs4 - 1 == lastindex(x)
 
@@ -96,7 +111,6 @@ end
             acc = acc - x[i + offs1] + x[i + offs3]
         end
         y[firstindex(y)] = acc * norm_factor
- 
         @inbounds @simd for i in firstindex(x):(lastindex(x) - offs4)
             acc = acc + x[i + offs1] - x[i + offs2] - x[i + offs3] + x[i + offs4]
             y[i + 1] = acc * norm_factor
@@ -116,7 +130,7 @@ end
 
 
 
-flt_output_smpltype(fi::TrapezoidalChargeFilterInstance) = flt_input_smpltype(fi)
+flt_output_smpltype(fi::TrapezoidalChargeFilterInstance) = float(flt_input_smpltype(fi))
 flt_input_smpltype(fi::TrapezoidalChargeFilterInstance{T}) where T = T
 flt_output_length(fi::TrapezoidalChargeFilterInstance) = flt_input_length(fi) - _filterlen(fi) + 1
 flt_input_length(fi::TrapezoidalChargeFilterInstance) = fi.n_input


### PR DESCRIPTION
Changed trapezoidal filter implementation to also handle asymmetrical filters. Behaviour for symmetrical filters remains as before by passing filter rise and flat top time as arguments. If passing rise, flat top and fall time, the filter reacts as asymmetrical filter. 
The figure shows the expected behaviour for a generic germanium detector waveform. 
![filter_implemenation](https://user-images.githubusercontent.com/46198814/203832648-fdf54ff3-7965-454c-a296-0d610010151e.png)
