### PR TITLE
Fixed intersect filter problem + added reverse and multiply waveform 

### DIFF
--- a/src/global_ops.jl
+++ b/src/global_ops.jl
@@ -89,6 +89,6 @@ end
 
 function bc_reverse_waveform(inputs::ArrayOfSimilarVectors{<:RealQuantity})
     X = flatview(inputs)
-    Y = reverse(X)
+    Y = reverse(X, dims = 1)
     ArrayOfSimilarVectors(Y)
 end

--- a/src/global_ops.jl
+++ b/src/global_ops.jl
@@ -30,3 +30,65 @@ function bc_shift_waveform(inputs::ArrayOfSimilarVectors{<:RealQuantity}, a)
     Y = X .+ a'
     ArrayOfSimilarVectors(Y)
 end
+
+
+"""
+    multiply_waveform(signal::AbstractSamples, a::RealQuantity)
+    multiply_waveform(wf::RDWaveform, a::RealQuantity)
+    
+Multiplies each sample of a waveform by `a`.
+"""
+function multiply_waveform end
+export multiply_waveform
+
+multiply_waveform(signal::AbstractSamples, a::RealQuantity) = signal .* a
+
+multiply_waveform(wf::RDWaveform, a::RealQuantity) = RDWaveform(wf.time, multiply_waveform(wf.signal, a))
+
+function Base.Broadcast.broadcasted(::typeof(multiply_waveform), inputs, a)
+    bc_multiply_waveform(Base.materialize(inputs), Base.materialize(a))
+end
+
+_nobcspec_multiply_waveform(inputs, a) = multiply_waveform(inputs, a)
+bc_multiply_waveform(inputs, a) = _nobcspec_multiply_waveform.(inputs, a)
+
+function bc_multiply_waveform(inputs::ArrayOfRDWaveforms, a)
+    ArrayOfRDWaveforms((inputs.time, broadcast(multiply_waveform, inputs.signal, a)))
+end
+
+function bc_multiply_waveform(inputs::ArrayOfSimilarVectors{<:RealQuantity}, a)
+    X = flatview(inputs)
+    Y = X .* a'
+    ArrayOfSimilarVectors(Y)
+end
+
+
+"""
+    reverse_waveform(signal::AbstractSamples)
+    reverse_waveform(wf::RDWaveform)
+
+Reverses the order of samples in a waveform.
+"""
+function reverse_waveform end
+export reverse_waveform
+
+reverse_waveform(signal::AbstractSamples) = reverse(signal)
+
+reverse_waveform(wf::RDWaveform) = RDWaveform(wf.time, reverse_waveform(wf.signal))
+
+function Base.Broadcast.broadcasted(::typeof(reverse_waveform), inputs)
+    bc_reverse_waveform(Base.materialize(inputs))
+end
+
+_nobcspec_reverse_waveform(inputs) = reverse_waveform(inputs)
+bc_reverse_waveform(inputs) = _nobcspec_reverse_waveform.(inputs)
+
+function bc_reverse_waveform(inputs::ArrayOfRDWaveforms)
+    ArrayOfRDWaveforms((inputs.time, broadcast(reverse_waveform, inputs.signal)))
+end
+
+function bc_reverse_waveform(inputs::ArrayOfSimilarVectors{<:RealQuantity})
+    X = flatview(inputs)
+    Y = reverse(X)
+    ArrayOfSimilarVectors(Y)
+end

--- a/src/intersect.jl
+++ b/src/intersect.jl
@@ -64,7 +64,9 @@ function _find_intersect_impl(X::AbstractVector{<:RealQuantity}, Y::AbstractVect
     y_r = Y[intersect_pos]
     intersect_cand_x = R(threshold - y_l) * R(x_r - x_l) / R(y_r - y_l) + R(x_l)
     @assert  y_l <= threshold <= y_r || n_intersects == 0
-    intersect_x = ifelse(n_intersects > 0, intersect_cand_x, R(NaN))
+    # TODO: return NaN if no intersect found but make sure it is compatible with the other routines
+    intersect_x  = ifelse(n_intersects > 0, intersect_cand_x, zero(intersect_cand_x))
+    n_intersects = ifelse(n_intersects > 0, n_intersects, 0)
 
     return (
         x =intersect_x,


### PR DESCRIPTION
To avoid problems with DSP chains, the `Intersect` filter now returns 0 instead of NaN and multiplicity 0 to prevent problems in the following DSP chains. In a later fix, we should aim for stable NaN returns if no intersect is found. 
Added two ner filters for global ops of waveform:
- `reverse_waveform`: reverses a waveform in the signal (s. picture)
- `multiply_wavform`: multiplies all samples in a waveform by a factor `a`. Useful for example to mirror the waveform by multiplying with -1 (s. figure)
![image](https://github.com/JuliaPhysics/RadiationDetectorDSP.jl/assets/46198814/9af59f71-6589-404b-b9f9-9270b1a34511)
