### PR TITLE
Numerical Instabilities in Signalstats

### DIFF
--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -50,7 +50,7 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     mean_X = sum_X * inv_n
     mean_Y = sum_Y * inv_n
     var_X = sum_X_sqr * inv_n - mean_X * mean_X
-    var_Y = sum_Y_sqr * inv_n - mean_Y * mean_Y
+    var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(mean_Y))
     cov_XY = sum_XY * inv_n - mean_X * mean_Y
 
     # mean_X_uncert = sqrt( (sum_X_sqr - sum_X * mean_X) / (n - 1) )
@@ -62,12 +62,6 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     offset = mean_Y - slope * mean_X
     # slope_uncert = sqrt( (var_X*var_Y - cov_XY*cov_XY) / (n - 2) ) / var_X
     # offset_uncert = slope_uncert * sqrt(sum_X_sqr * inv_n)
-
-    # ToDo: Try to avoid if and catch that case maybe earlier
-    # avoid numerical instabilities if all Y's are equal
-    if var_Y < zero(var_Y)
-        var_Y = zero(var_Y)
-    end
 
     (
         mean = mean_Y,

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -64,8 +64,8 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     # offset_uncert = slope_uncert * sqrt(sum_X_sqr * inv_n)
 
     # avoid numerical instabilities if all Y's are equal
-    var_Y = if var_Y < 0 && mean_Y == Y[1]
-        zero(var_Y)
+    if var_Y < zero(var_Y)
+        var_Y = zero(var_Y)
     end
 
     (

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -63,6 +63,11 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     # slope_uncert = sqrt( (var_X*var_Y - cov_XY*cov_XY) / (n - 2) ) / var_X
     # offset_uncert = slope_uncert * sqrt(sum_X_sqr * inv_n)
 
+    # avoid numerical instabilities if all Y's are equal
+    var_Y = if var_Y < 0 && mean_Y == Y[1]
+        zero(var_Y)
+    end
+
     (
         mean = mean_Y,
         sigma = sqrt(var_Y),

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -50,6 +50,7 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     # mean_X = sum_X * inv_n
     mean_Y = sum_Y * inv_n
     # var_X = sum_X_sqr * inv_n - mean_X * mean_X
+   # Ensure var_Y is not negative:
     var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(mean_Y))
     # cov_XY = sum_XY * inv_n - mean_X * mean_Y
 

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -47,11 +47,11 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     n = length(idxs)
     inv_n = inv(n)
 
-    mean_X = sum_X * inv_n
+    # mean_X = sum_X * inv_n
     mean_Y = sum_Y * inv_n
-    var_X = sum_X_sqr * inv_n - mean_X * mean_X
+    # var_X = sum_X_sqr * inv_n - mean_X * mean_X
     var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(mean_Y))
-    cov_XY = sum_XY * inv_n - mean_X * mean_Y
+    # cov_XY = sum_XY * inv_n - mean_X * mean_Y
 
     # mean_X_uncert = sqrt( (sum_X_sqr - sum_X * mean_X) / (n - 1) )
     # mean_Y_uncert = sqrt( (sum_Y_sqr - sum_Y * mean_Y) / (n - 1) )

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -50,7 +50,7 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     # mean_X = sum_X * inv_n
     mean_Y = sum_Y * inv_n
     # var_X = sum_X_sqr * inv_n - mean_X * mean_X
-   # Ensure var_Y is not negative:
+    # Ensure var_Y is not negative:
     var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(mean_Y))
     # cov_XY = sum_XY * inv_n - mean_X * mean_Y
 

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -63,6 +63,7 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     # slope_uncert = sqrt( (var_X*var_Y - cov_XY*cov_XY) / (n - 2) ) / var_X
     # offset_uncert = slope_uncert * sqrt(sum_X_sqr * inv_n)
 
+    # ToDo: Try to avoid if and catch that case maybe earlier
     # avoid numerical instabilities if all Y's are equal
     if var_Y < zero(var_Y)
         var_Y = zero(var_Y)


### PR DESCRIPTION
In case signalstats processes a saturated waveform (signals with only FADC max values), the signalstats estimator throws errors since it tries to take the `sqrt` of the `var_Y` after finishing the interpolation. 
Fixed with a `if` clause for now since otherwise not al waveforms can be broadcasted.