### PR TITLE
Fix start values of `FIIR` and Biquad filter to second sample

### DIFF
--- a/src/biquad_filter.jl
+++ b/src/biquad_filter.jl
@@ -83,7 +83,8 @@ end
     end
 
     # fix start value
-    Y[1] = Y[2]
+    Y[1] = Y[3]
+    Y[2] = Y[3]
     
     Y
 end

--- a/src/biquad_filter.jl
+++ b/src/biquad_filter.jl
@@ -81,6 +81,10 @@ end
         s1 = fma(neg_a1, y_i, z2)
         s2 = fma(neg_a2, y_i, z3)
     end
+
+    # fix start value
+    Y[1] = Y[2]
+    
     Y
 end
 

--- a/src/first_order_iir.jl
+++ b/src/first_order_iir.jl
@@ -99,6 +99,10 @@ X::AbstractVector{U}) where {T<:Real, U<:Real}
 
         s1 = fma(neg_a1, y_i, z2)
     end
+
+    # fix start value
+    Y[1] = Y[2]
+
     Y
 end
 


### PR DESCRIPTION
In the current implementation of the `FIIR` and `Biquad` filters, the first sample is off since the algorithms starts with an initial state of `zero(T)`. This creates unwanted behavior e.g. for the `DifferentiatorFilter`:
<img width="660" alt="image" src="https://github.com/user-attachments/assets/616b5586-2c34-441d-b4e1-0011cd2990ff" />
The fix sets the first sample to the value of the second sample to avoid this behavior:
<img width="663" alt="image" src="https://github.com/user-attachments/assets/c88b4e78-2e27-47e5-9157-fbbdfebbc297" />


 