### PR TITLE
Fix `signalstats` implementation when having samples with units

### DIFF
--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -51,7 +51,7 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     mean_Y = sum_Y * inv_n
     var_X = sum_X_sqr * inv_n - mean_X * mean_X
     # Ensure var_Y is not negative:
-    var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(mean_Y))
+    var_Y = max(sum_Y_sqr * inv_n - mean_Y * mean_Y, zero(sum_Y_sqr))
     cov_XY = sum_XY * inv_n - mean_X * mean_Y
 
     # mean_X_uncert = sqrt( (sum_X_sqr - sum_X * mean_X) / (n - 1) )


### PR DESCRIPTION
In PR #41, code was introduced that fails if the samples have units:

```julia
using RadiationDetectorDSP
using RadiationDetectorSignals
using Unitful

wf = RDWaveform((0:100)u"ns", randn(101)u"C")
signalstats(wf, 0u"ns", 100u"ns")
```
```
ERROR: DimensionError: 0.0 C and 1.0373625148197236 C^2 are not dimensionally compatible.
Stacktrace:
 [1] _isless
   @ ~/Software/Unitful.jl/src/quantities.jl:250 [inlined]
 [2] isless(x::Quantity{Float64, 𝐈 𝐓, Unitful.FreeUnits{…}}, y::Quantity{Float64, 𝐈^2 𝐓^2, Unitful.FreeUnits{…}})
   @ Unitful ~/Software/Unitful.jl/src/quantities.jl:240
 [3] max(x::Quantity{Float64, 𝐈^2 𝐓^2, Unitful.FreeUnits{…}}, y::Quantity{Float64, 𝐈 𝐓, Unitful.FreeUnits{…}})
   @ Base ./operators.jl:481
 [4] _signalstats_impl(X::StepRange{Quantity{…}, Quantity{…}}, Y::Vector{Quantity{…}}, idxs::UnitRange{Int64})
   @ RadiationDetectorDSP ~/.julia/packages/RadiationDetectorDSP/zR8oQ/src/signalstats.jl:54
 [5] signalstats(input::RDWaveform{…}, start::Quantity{…}, stop::Quantity{…})
   @ RadiationDetectorDSP ~/.julia/packages/RadiationDetectorDSP/zR8oQ/src/signalstats.jl:21
 [6] top-level scope
   @ REPL[8]:1
```

After this PR, `signalstats` does not fail and the output looks like this:
```
(mean = 0.07191460017009416 C, sigma = 0.9393140224212858 C, slope = -0.0040645798613581545 C ns^-1, offset = 0.27514359323800186 C)
```
