### PR TITLE
add slope RMS to signalstats

### DIFF
--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -64,10 +64,14 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
     # slope_uncert = sqrt( (var_X*var_Y - cov_XY*cov_XY) / (n - 2) ) / var_X
     # offset_uncert = slope_uncert * sqrt(sum_X_sqr * inv_n)
 
+    var_slope = var_Y - cov_XY * cov_XY / var_X
+    sigma_slope = sqrt(max(var_slope, zero(var_slope)))
+
     (
         mean = mean_Y,
         sigma = sqrt(var_Y),
         slope = slope,
         offset = offset,
+        sigma_2 = sigma_slope,
     )
 end

--- a/src/signalstats.jl
+++ b/src/signalstats.jl
@@ -72,6 +72,6 @@ function _signalstats_impl(X::AbstractArray{<:RealQuantity}, Y::AbstractArray{<:
         sigma = sqrt(var_Y),
         slope = slope,
         offset = offset,
-        sigma_2 = sigma_slope,
+        slope_residual_sigma = sigma_slope,
     )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ Test.@testset "Package RadiationDetectorDSP" begin
     include("test_zac_filter.jl")
     include("test_cusp_filter.jl")
     include("test_gaussian_filter.jl")
+    include("test_signal_stats.jl")
 
     # doctests
     Documenter.DocMeta.setdocmeta!(

--- a/test/test_signal_stats.jl
+++ b/test/test_signal_stats.jl
@@ -1,0 +1,31 @@
+# This file is a part of RadiationDetectorDSP.jl, licensed under the MIT License (MIT).
+using Test
+
+include("test_utils.jl")
+
+@testset "signalstats" begin
+    # Flat signal: mean=5, sigma=0, slope=0
+    xs = 0.0:1.0:9.0
+    ys = fill(5.0, 10)
+    wf = RDWaveform(xs, ys)
+
+    stats = signalstats(wf, 0.0, 9.0)
+    @test stats.mean ≈ 5.0
+    @test stats.sigma ≈ 0.0 atol=1e-10
+    @test stats.slope ≈ 0.0 atol=1e-10
+    @test stats.offset ≈ 5.0
+
+    # Linear signal y = 2x + 1: slope=2, offset=1, sigma small
+    ys_linear = 2.0 .* collect(xs) .+ 1.0
+    wf_linear = RDWaveform(xs, ys_linear)
+
+    stats_linear = signalstats(wf_linear, 0.0, 9.0)
+    @test stats_linear.slope ≈ 2.0 atol=1e-10
+    @test stats_linear.offset ≈ 1.0 atol=1e-10
+    @test stats_linear.slope_residual_sigma ≈ 0.0 atol=1e-10
+
+    # Subrange: only use x in [2.0, 5.0]
+    stats_sub = signalstats(wf_linear, 2.0, 5.0)
+    @test stats_sub.slope ≈ 2.0 atol=1e-10
+    @test stats_sub.mean ≈ 2.0 * 3.5 + 1.0 atol=1e-10  # mean x in [2,5] = 3.5
+end


### PR DESCRIPTION
Currently signalstats only returns the RMS from a constant (the mean). 
This Pull Request adds the RMS of slope fitted by the signalstats function.

@oschulz can you have a look at this? Can this be implemented like this? Should this always be computed and returned of be turned on/off by a kwarg? 
Also do you have a name suggestion? Maybe slope_rms? 