### PR TITLE
Add sum_waveforms function

### DIFF
--- a/src/global_ops.jl
+++ b/src/global_ops.jl
@@ -94,27 +94,30 @@ function bc_reverse_waveform(inputs::ArrayOfSimilarVectors{<:RealQuantity})
 end
 
 """
-    create_superpuls(wfs::AbstractVector{<:RDWaveform})
+    sum_waveforms(wfs::AbstractVector{<:RDWaveform})
 
-Creates a superpulse (sample-wise sum) of an array of waveforms.
+Creates a sample-wise sum of an array of waveforms.
 All waveforms are assumed to share the same time axis.
 """
-function create_superpuls end
-export create_superpuls
+function sum_waveforms end
+export sum_waveforms
 
-function create_superpuls(wfs::AbstractVector{<:RDWaveform})
+function sum_waveforms(wfs::AbstractVector{<:RDWaveform})
     time = first(wfs).time
-    signal = create_superpuls(map(wf -> wf.signal, wfs))
+    @assert all(wf -> wf.time == time, wfs) "all waveforms must share the same time axis"
+    signal = sum_waveforms(map(wf -> wf.signal, wfs))
     RDWaveform(time, signal)
 end
 
-create_superpuls(signals::AbstractVector{<:AbstractSamples}) = sum(signals)
+sum_waveforms(signals::AbstractVector{<:AbstractSamples}) = sum(signals)
 
-function create_superpuls(wfs::ArrayOfRDWaveforms)
-    RDWaveform(wfs.time, create_superpuls(wfs.signal))
+function sum_waveforms(wfs::ArrayOfRDWaveforms)
+    time = first(wfs.time)
+    @assert all(==(time), wfs.time) "all waveforms must share the same time axis"
+    RDWaveform(time, sum_waveforms(wfs.signal))
 end
 
-function create_superpuls(signals::ArrayOfSimilarVectors{<:RealQuantity})
+function sum_waveforms(signals::ArrayOfSimilarVectors{<:RealQuantity})
     X = flatview(signals)
     vec(sum(X, dims = 2))
 end

--- a/src/global_ops.jl
+++ b/src/global_ops.jl
@@ -92,3 +92,29 @@ function bc_reverse_waveform(inputs::ArrayOfSimilarVectors{<:RealQuantity})
     Y = reverse(X, dims = 1)
     ArrayOfSimilarVectors(Y)
 end
+
+"""
+    create_superpuls(wfs::AbstractVector{<:RDWaveform})
+
+Creates a superpulse (sample-wise sum) of an array of waveforms.
+All waveforms are assumed to share the same time axis.
+"""
+function create_superpuls end
+export create_superpuls
+
+function create_superpuls(wfs::AbstractVector{<:RDWaveform})
+    time = first(wfs).time
+    signal = create_superpuls(map(wf -> wf.signal, wfs))
+    RDWaveform(time, signal)
+end
+
+create_superpuls(signals::AbstractVector{<:AbstractSamples}) = sum(signals)
+
+function create_superpuls(wfs::ArrayOfRDWaveforms)
+    RDWaveform(wfs.time, create_superpuls(wfs.signal))
+end
+
+function create_superpuls(signals::ArrayOfSimilarVectors{<:RealQuantity})
+    X = flatview(signals)
+    vec(sum(X, dims = 2))
+end

--- a/test/test_global_ops.jl
+++ b/test/test_global_ops.jl
@@ -14,4 +14,14 @@ include("test_utils.jl")
         @test broadcast(shift_waveform, wfs_x, A).signal isa ArrayOfSimilarVectors 
         # ToDo: Add more detailed tests for shift_waveform
     end
+
+    @testset "create_superpuls" begin
+        wfs_x = gen_test_waveforms()
+        @test @inferred(create_superpuls(wfs_x)) ≈ RDWaveform(wfs_x[1].time, sum(map(wf -> wf.signal, wfs_x)))
+        @test create_superpuls(wfs_x).time == wfs_x[1].time
+        @test create_superpuls(wfs_x).signal isa AbstractVector
+        @test create_superpuls([wfs_x[1]]) ≈ wfs_x[1]
+        @test create_superpuls(wfs_x).signal ≈ sum(broadcast(wf -> wf.signal, wfs_x))
+        @test_throws BoundsError create_superpuls(similar(wfs_x, 0))
+    end
 end

--- a/test/test_global_ops.jl
+++ b/test/test_global_ops.jl
@@ -15,13 +15,13 @@ include("test_utils.jl")
         # ToDo: Add more detailed tests for shift_waveform
     end
 
-    @testset "create_superpuls" begin
+    @testset "sum_waveforms" begin
         wfs_x = gen_test_waveforms()
-        @test @inferred(create_superpuls(wfs_x)) ≈ RDWaveform(wfs_x[1].time, sum(map(wf -> wf.signal, wfs_x)))
-        @test create_superpuls(wfs_x).time == wfs_x[1].time
-        @test create_superpuls(wfs_x).signal isa AbstractVector
-        @test create_superpuls([wfs_x[1]]) ≈ wfs_x[1]
-        @test create_superpuls(wfs_x).signal ≈ sum(broadcast(wf -> wf.signal, wfs_x))
-        @test_throws BoundsError create_superpuls(similar(wfs_x, 0))
+        @test @inferred(sum_waveforms(wfs_x)) ≈ RDWaveform(wfs_x[1].time, sum(map(wf -> wf.signal, wfs_x)))
+        @test sum_waveforms(wfs_x).time == wfs_x[1].time
+        @test sum_waveforms(wfs_x).signal isa AbstractVector
+        @test sum_waveforms([wfs_x[1]]) ≈ wfs_x[1]
+        @test sum_waveforms(wfs_x).signal ≈ sum(broadcast(wf -> wf.signal, wfs_x))
+        @test_throws BoundsError sum_waveforms(similar(wfs_x, 0))
     end
 end


### PR DESCRIPTION
This PR adds a `sum_waveforms` function to calculate the sample-wise sum of multiple waveforms. This is useful for creating superpulses.

I added it here because we already have similar functions such as `shift_waveform` and `multiply_waveform`. To fit the other functions, I also chose the name `sum_waveforms` instead of something like `create_superpulse`. If you have any different naming suggestions, please let me know.

I also added some simple tests.
