### PR TITLE
Use smoothstep for lsqfit window blending

### DIFF
--- a/src/lsqfit.jl
+++ b/src/lsqfit.jl
@@ -49,8 +49,7 @@ function _lsqfitatpos_impl(A_slqfit::AbstractMatrix{<:Real}, X::AbstractRange{<:
 
     range_r = (from+1):(until+1)
     shifted_x_r = xi - first(range_r)
-    #weight_r = _smoothstep(mod(shifted_x_r, 1))
-    weight_r = mod(shifted_x_r, 1)
+    weight_r = _smoothstep(mod(shifted_x_r, 1))
     y_r = _lsqfitatpos_single_impl(A_slqfit, view(Y, range_r), shifted_x_r)
 
     range_l = (from):(until)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ Test.@testset "Package RadiationDetectorDSP" begin
     include("test_cusp_filter.jl")
     include("test_gaussian_filter.jl")
     include("test_signal_stats.jl")
+    include("test_lsqfit.jl")
 
     # doctests
     Documenter.DocMeta.setdocmeta!(

--- a/test/test_lsqfit.jl
+++ b/test/test_lsqfit.jl
@@ -1,0 +1,29 @@
+# This file is a part of RadiationDetectorDSP.jl, licensed under the MIT License (MIT).
+
+using RadiationDetectorDSP
+using Test
+
+using RadiationDetectorDSP: _lsq_fit_matrix, _lsqfitatpos_single_impl, _smoothstep, lsqfitatpos
+
+@testset "lsqfitatpos" begin
+    @testset "uses smoothstep window blending" begin
+        degree = 1
+        n = 3
+        X = 1.0:1.0:10.0
+        Y = [0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        x = 5.25
+
+        A_lsqfit = _lsq_fit_matrix(0:(n - 1), degree)
+        xi = (x - first(X)) / step(X) + firstindex(X)
+        from = floor(Integer, xi) - div(n - 1, 2)
+        until = from + n - 1
+
+        y_l = _lsqfitatpos_single_impl(A_lsqfit, view(Y, from:until), xi - from)
+        y_r = _lsqfitatpos_single_impl(A_lsqfit, view(Y, (from + 1):(until + 1)), xi - (from + 1))
+        w_linear = mod(xi - (from + 1), 1)
+        w_smooth = _smoothstep(w_linear)
+
+        @test lsqfitatpos(degree, n, X, Y, x) ≈ (1 - w_smooth) * y_l + w_smooth * y_r
+        @test lsqfitatpos(degree, n, X, Y, x) != (1 - w_linear) * y_l + w_linear * y_r
+    end
+end


### PR DESCRIPTION
Fixes #70.

This changes lsqfitatpos window blending to use the existing _smoothstep helper instead of a linear fractional weight. The smoother weight was already present as dead/commented code, so this restores the intended smooth transition between neighboring fit windows.

I also added a focused regression test that compares the public lsqfitatpos result against smoothstep-weighted left/right least-squares fits and checks that it differs from the old linear blend.

Checks:
- git diff --check
- Full Julia test suite not run locally because Julia is not installed in the execution environment.